### PR TITLE
Fix name of distribution

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -17,6 +17,6 @@ done
 
 # Install packages and test
 for PYBIN in /opt/python/*/bin/; do
-    ${PYBIN}/pip install python_manylinux_demo --no-index -f /io/wheelhouse
+    ${PYBIN}/pip install python-manylinux-demo --no-index -f /io/wheelhouse
     (cd $HOME; ${PYBIN}/nosetests pymanylinuxdemo)
 done


### PR DESCRIPTION
From the looks of setup.py, it's "python-manylinux-demo" right? (With dashes)
