### PR TITLE
shell best practice: fully quote every variable

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -6,17 +6,17 @@ yum install -y atlas-devel
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
-    ${PYBIN}/pip install -r /io/dev-requirements.txt
-    ${PYBIN}/pip wheel /io/ -w wheelhouse/
+    "${PYBIN}/pip" install -r /io/dev-requirements.txt
+    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 done
 
 # Bundle external shared libraries into the wheels
 for whl in wheelhouse/*.whl; do
-    auditwheel repair $whl -w /io/wheelhouse/
+    auditwheel repair "$whl" -w /io/wheelhouse/
 done
 
 # Install packages and test
 for PYBIN in /opt/python/*/bin/; do
-    ${PYBIN}/pip install python-manylinux-demo --no-index -f /io/wheelhouse
-    (cd $HOME; ${PYBIN}/nosetests pymanylinuxdemo)
+    "${PYBIN}/pip" install python-manylinux-demo --no-index -f /io/wheelhouse
+    (cd "$HOME"; "${PYBIN}/nosetests" pymanylinuxdemo)
 done


### PR DESCRIPTION
This avoids expansion issues with spaces