### PR TITLE
Skip no-platform wheels when repairing

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -12,7 +12,8 @@ done
 
 # Bundle external shared libraries into the wheels
 for whl in wheelhouse/*.whl; do
-    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/
+    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/ \
+        || echo "Skipping non-platform wheel $whl"
 done
 
 # Install packages and test


### PR DESCRIPTION
In case non-platform wheels are in `wheelhouse`, print a message and
skip them instead of prematurely failing the build script.

Resolves: #21 
Resolves: #7 