### PR TITLE
Use `auditwheel show` to detect platform wheels

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e -x
 
+function repair_wheel {
+    wheel="$1"
+    if ! auditwheel show "$wheel"; then
+        echo "Skipping non-platform wheel $wheel"
+    else
+        auditwheel repair "$wheel" --plat "$PLAT" -w /io/wheelhouse/
+    fi
+}
+
+
 # Install a system package required by our library
 yum install -y atlas-devel
 
@@ -12,8 +22,7 @@ done
 
 # Bundle external shared libraries into the wheels
 for whl in wheelhouse/*.whl; do
-    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/ \
-        || echo "Skipping non-platform wheel $whl"
+    repair_wheel "$whl"
 done
 
 # Install packages and test


### PR DESCRIPTION
To avoid masking errors when skipping non-platform wheels, use
`auditwheel show` first to detect platform wheels.