### PR TITLE
Set -u to ensure PLAT is set

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -x
+set -e -u -x
 
 function repair_wheel {
     wheel="$1"


### PR DESCRIPTION
Treat unset variables as an error when substituting
to ensure that `PLAT` is set and not empty.

This script is tightly coupled with the variables specified in travis.yaml, but
for other users of this demo, they might be, for instance, walking through this script interactively
in an attached container.