### PR TITLE
The PyPA has adopted the PSF code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Code of Conduct
 
 Everyone interacting in the python-manylinux-demo project's codebases, issue trackers,
 chat rooms, and mailing lists is expected to follow the
-[PyPA Code of Conduct](https://www.pypa.io/en/latest/code-of-conduct/).
+[PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).
 
 License
 -------


### PR DESCRIPTION
For details, see:

* https://discuss.python.org/t/implementing-pep-609-pypa-governance/4745